### PR TITLE
Fix social post image display

### DIFF
--- a/client/src/components/ShareButton.tsx
+++ b/client/src/components/ShareButton.tsx
@@ -44,7 +44,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ result, resultId, onPublicSta
   };
 
   // Mobile-specific social sharing
-  const openSocialApp = (platform: 'twitter' | 'reddit', url: string, text: string) => {
+  const openSocialApp = (platform: 'twitter' | 'reddit', url: string, text: string, mobileLinkUrl?: string) => {
     const isMobile = isMobileDevice();
     console.log('📱 Device type:', isMobile ? 'Mobile' : 'Desktop');
     
@@ -52,9 +52,11 @@ const ShareButton: React.FC<ShareButtonProps> = ({ result, resultId, onPublicSta
       try {
         let appUrl: string;
         if (platform === 'twitter') {
-          appUrl = `twitter://post?message=${encodeURIComponent(text + ' ' + url)}`;
+          const linkForMobile = mobileLinkUrl || url;
+          appUrl = `twitter://post?message=${encodeURIComponent(text + ' ' + linkForMobile)}`;
         } else {
-          appUrl = `reddit://submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent(text)}`;
+          const linkForMobile = mobileLinkUrl || url;
+          appUrl = `reddit://submit?url=${encodeURIComponent(linkForMobile)}&title=${encodeURIComponent(text)}`;
         }
         
         window.location.href = appUrl;
@@ -91,7 +93,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ result, resultId, onPublicSta
 
   // Construct share text
   const foodItemsText = result.foodItems.join(', ');
-  const shareText = `🍽️ Just analyzed my food with AI! Found ${foodItemsText} - ${result.totalCalories} calories total. Check out this amazing CaloriTrack app!`;
+  const shareText = `🍽️ ${foodItemsText} — ${result.totalCalories} kcal via CaloriTrack`;
   
   // Create shareable link (for public result viewing)
   // Use custom domain for user-facing links
@@ -252,7 +254,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ result, resultId, onPublicSta
       console.log('🐦 Twitter intent URL:', twitterUrl);
       
       // Use mobile-specific sharing utility
-      openSocialApp('twitter', twitterUrl, shareText);
+      openSocialApp('twitter', twitterUrl, shareText, ogUrl);
       
       logShareEvent('twitter');
       setIsOpen(false);
@@ -276,7 +278,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ result, resultId, onPublicSta
         console.log('🌐 Fallback: Opening Twitter with URL:', ogUrl);
         
         // Use mobile-specific sharing utility
-        openSocialApp('twitter', twitterUrl, shareText);
+        openSocialApp('twitter', twitterUrl, shareText, ogUrl);
         
         logShareEvent('twitter');
         setIsOpen(false);
@@ -322,7 +324,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ result, resultId, onPublicSta
       const redditUrl = `https://reddit.com/submit?url=${encodeURIComponent(ogUrl)}&title=${encodeURIComponent(shareText)}`;
       
       // Use mobile-specific sharing utility
-      openSocialApp('reddit', redditUrl, shareText);
+      openSocialApp('reddit', redditUrl, shareText, ogUrl);
       
       logShareEvent('reddit');
       setIsOpen(false);
@@ -638,7 +640,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ result, resultId, onPublicSta
                       const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(ogUrl)}`;
                         
                         // Use mobile-specific sharing utility
-                        openSocialApp('twitter', twitterUrl, shareText);
+                        openSocialApp('twitter', twitterUrl, shareText, ogUrl);
                         
                         logShareEvent('twitter');
                         setIsOpen(false);

--- a/client/src/pages/PublicResult.tsx
+++ b/client/src/pages/PublicResult.tsx
@@ -275,7 +275,7 @@ const PublicResult: React.FC = () => {
               </Link>
               <button
                 onClick={() => {
-                  const shareText = `🍽️ Check out this food analysis! Found ${result.food_items?.join(', ') || 'delicious food'} - ${result.total_calories} calories total. Try analyzing your own food at https://calorie.codedcheese.com`;
+                  const shareText = `🍽️ Food analysis: ${result.food_items?.join(', ') || 'meal'} — ${result.total_calories} kcal. Try it: https://calorie.codedcheese.com`;
                   navigator.clipboard.writeText(shareText);
                   trackPublicResultShare(result.id);
                   alert('Share text copied to clipboard!');

--- a/server/server.js
+++ b/server/server.js
@@ -921,6 +921,7 @@ app.get('/og/:resultId', async (req, res) => {
           <meta property="og:title" content="CaloriTrack - ${foodItemsText}" />
           <meta property="og:description" content="${foodItemsText} - ${result.total_calories} calories total. Analyzed with AI-powered CaloriTrack!" />
           <meta property="og:image" content="${socialImageUrl}" />
+          <meta property="og:image:secure_url" content="${socialImageUrl}" />
           <meta property="og:image:width" content="1200" />
           <meta property="og:image:height" content="630" />
           <meta property="og:image:alt" content="CaloriTrack food analysis showing ${foodItemsText} with ${result.total_calories} calories" />
@@ -933,8 +934,10 @@ app.get('/og/:resultId', async (req, res) => {
           <meta name="twitter:title" content="CaloriTrack - ${foodItemsText}" />
           <meta name="twitter:description" content="${foodItemsText} - ${result.total_calories} calories total. Analyzed with AI-powered CaloriTrack!" />
           <meta name="twitter:image" content="${socialImageUrl}" />
+          <meta name="twitter:image:src" content="${socialImageUrl}" />
           <meta name="twitter:image:alt" content="CaloriTrack food analysis showing ${foodItemsText} with ${result.total_calories} calories" />
           <meta name="twitter:site" content="@caloritrack" />
+          <meta name="twitter:url" content="${process.env.FRONTEND_URL || 'https://calorie.codedcheese.com'}/result/${resultId}" />
           
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         </head>


### PR DESCRIPTION
Fix Twitter/Reddit social sharing to ensure image cards display reliably and improve tweet text clarity.

Previously, mobile deep-linking for Twitter used the full intent URL in the tweet body, which prevented the image card from rendering and cluttered the tweet text. This PR updates the mobile deep-link to use the Open Graph (OG) URL directly and enhances meta tags for better card previews.

---
<a href="https://cursor.com/background-agent?bcId=bc-06699e99-37f9-47f8-adca-cccaf211f1d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06699e99-37f9-47f8-adca-cccaf211f1d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

